### PR TITLE
add zoom to ability tree pages, fix backbutton in ability page

### DIFF
--- a/frontend/app/(protected)/abilities/[abilityName]/_components/BackButton.tsx
+++ b/frontend/app/(protected)/abilities/[abilityName]/_components/BackButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { ArrowBack } from "@mui/icons-material";
+import React from "react";
+import { useRouter } from "next/navigation";
+
+function BackButton() {
+  const router = useRouter();
+  return (
+    <div>
+      <ArrowBack
+        onClick={() => router.back()}
+        sx={{
+          fontSize: "3rem",
+          ":hover": { color: "white", cursor: "pointer" },
+          color: "grey",
+        }}
+        className="cursor-pointer"
+      />
+    </div>
+  );
+}
+
+export default BackButton;

--- a/frontend/app/(protected)/abilities/[abilityName]/page.tsx
+++ b/frontend/app/(protected)/abilities/[abilityName]/page.tsx
@@ -22,8 +22,8 @@ import AbilityForm from "./_components/AbilityForm";
 import Image from "next/image";
 import { $Enums } from "@prisma/client";
 import { checkIfPassiveIsActive } from "@/data/passives/getPassive";
-import Link from "next/link";
-import { ArrowBack, Diamond, Favorite, WaterDrop } from "@mui/icons-material";
+import { Diamond, Favorite, WaterDrop } from "@mui/icons-material";
+import BackButton from "./_components/BackButton";
 
 export default async function AbilityNamePage({
   params,
@@ -83,16 +83,9 @@ export default async function AbilityNamePage({
         >
           {/* back button */}
           <div className="flex justify-between w-full">
-            <Link href="/abilities">
-              <ArrowBack
-                sx={{
-                  fontSize: "3rem",
-                  ":hover": { color: "white", cursor: "pointer" },
-                  color: "grey",
-                }}
-                className="cursor-pointer"
-              />
-            </Link>
+            <div className="flex flex-col">
+              <BackButton />
+            </div>
 
             <div
               className={

--- a/frontend/app/(protected)/abilities/_components/AbilityTree.tsx
+++ b/frontend/app/(protected)/abilities/_components/AbilityTree.tsx
@@ -82,7 +82,7 @@ export default function AbilityTree({
           pathFunc={"diagonal"}
           pathClassFunc={() => "linkClass"}
           draggable={true}
-          zoomable={false}
+          zoomable={true}
           // The nodeSize prop is used to determine the spacing between nodes
           nodeSize={{ x: 475, y: 350 }}
           renderCustomNodeElement={(rd3tProps) => {


### PR DESCRIPTION
# What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix and feature
<!--
- Describe the changes here.
-->


# What is the current behavior? (You can also link to an open issue here)
currently you can't zoom in the ability tree tabs and the back buttons in the ability pages makes you always go back to the trees
<!--
- Describe the current behavior here.  
-->


# What is the new behavior? (If this is a feature change)
it now allows you to zoom in the ability trees page, and the back button takes you to your last visited page
<!--
- Describe the new feature here.  
-->

