### PR TITLE
Suggestion for a new cosmic event

### DIFF
--- a/backend/src/db/cosmic.ts
+++ b/backend/src/db/cosmic.ts
@@ -963,6 +963,21 @@ const cosmic: CosmicEvent[] = [
     grantAbility: false,
     abilityName: null,
   },
+  {
+    id: 62,
+    name: "The-Fractured-Aurora",
+    description: "A shimmering rift opens in the sky above Tiller. Instead of normal northern lights, the aurora fractures into gemstones, granting all students 2 Gemstones",
+    // icon: ".png"
+    // presetDate: "",
+    frequency: 5,
+    automatic: false,
+    increaseCostType: null,
+    increaseCostValue: null,
+    blockAbilityType: null,
+    triggerAtNoon: false,
+    grantAbility: false,
+    abilityName: null,
+  },
 ];
 const cosmics = [...cosmic];
 export default cosmics;


### PR DESCRIPTION
A cosmic event which grants students 2 gemstones

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Adds a new cosmic event that rewards students with 2 gemstones.


## What is the current behavior? (You can also link to an open issue here)

There is no cosmic event granting gemstones in the game.


## What is the new behavior? (If this is a feature change)

When the cosmic event triggers, each student receives 2 gemstones.

## Test Cases

- [x] Trigger the cosmic event and verify that students receive 2 gemstones each.


## Does this PR introduce a breaking change?

No, this is an additive feature and does not affect existing functionality.

## Additional Information

Gemstones are added through the existing reward system so it does not conflict with any existing systems.
